### PR TITLE
Uso de itálica para palabras en inglés y otros

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Invera ToDo-List Challenge (Python/Django Jr-SSr)
+# Invera's ToDo-List Challenge (Python/Django Jr-SSr)
 
-El propósito de esta prueba es conocer tu capacidad para crear una pequeña aplicación funcional en un límite de tiempo. A continuación, encontrarás las funciones, los requisitos y los puntos clave que debés tener en cuenta durante el desarrollo.
+El propósito de esta prueba es conocer tu capacidad para crear una pequeña aplicación funcional en un límite de tiempo. A continuación, encontrarás las funciones, los requisitos y los puntos clave que debes tener en cuenta durante el desarrollo.
 
-## Qué queremos que hagas:
+## ¿Qué queremos que hagas?
 
-- El Challenge consiste en crear una aplicación web sencilla que permita a los usuarios crear y mantener una lista de tareas.
-- La entrega del resultado será en un nuevo fork de este repo y deberás hacer una pequeña demo del funcionamiento y desarrollo del proyecto ante un super comité de las más grandes mentes maestras de Invera, o a un par de devs, lo que sea más fácil de conseguir.
+- El _challenge_ consiste en crear una aplicación _web_ sencilla que permita a los usuarios crear y mantener una lista de tareas.
+- La entrega del resultado será en un nuevo _fork_ de este repo y deberás hacer una pequeña demo del funcionamiento y desarrollo del proyecto ante un súper comité de las más grandes mentes maestras de Invera, o a un par de _devs_, lo que sea más fácil de conseguir.
 - Podes contactarnos en caso que tengas alguna consulta.
 
-## Objetivos:
+## Objetivos
 
 El usuario de la aplicación tiene que ser capaz de:
 
@@ -17,21 +17,21 @@ El usuario de la aplicación tiene que ser capaz de:
 - Eliminar una tarea
 - Marcar tareas como completadas
 - Poder ver una lista de todas las tareas existentes
-- Filtrar/buscar tareas por fecha de creación y/o por el contenido de la misma
+- Filtrar/Buscar tareas por fecha de creación y/o por el contenido de la misma
 
-## Qué evaluamos:
+## ¿Qué evaluamos?
 
-- Desarrollo utilizando Python, Django. No es necesario crear un Front-End, pero sí es necesario tener una API que permita cumplir con los objetivos de arriba.
-- Uso de librerías y paquetes estandares que reduzcan la cantidad de código propio añadido.
+- Desarrollo utilizando Python y Django. No es necesario crear un _front-end_, pero sí es necesario tener una API que permita cumplir con los objetivos de arriba.
+- Uso de librerías y paquetes estándares que reduzcan la cantidad de código propio añadido.
 - Calidad y arquitectura de código. Facilidad de lectura y mantenimiento del código. Estándares seguidos.
 - [Bonus] Manejo de logs.
-- [Bonus] Creación de tests (unitarias y de integración)
-- [Bonus] Unificar la solución propuesta en una imagen de Docker por repositorio para poder ser ejecutada en cualquier ambiente (si aplica para full stack).
+- [Bonus] Creación de _tests_ (unitarias y de integración).
+- [Bonus] Unificar la solución propuesta en una imagen de Docker por repositorio para poder ser ejecutada en cualquier ambiente (si aplica para _full-stack_).
 
-## Requerimientos de entrega:
+## Requerimientos de entrega
 
-- Hacer un fork del proyecto y pushearlo en github. Puede ser privado.
+- Hacer un _fork_ del proyecto y pushearlo en GitHub. Puede ser privado.
 - La solución debe correr correctamente.
-- El Readme debe contener todas las instrucciones para poder levantar la aplicación, en caso de ser necesario, y explicar cómo se usa.
-- Disponibilidad para realizar una pequeña demo del proyecto al finalizar el challenge.
-- Tiempo para la entrega: Aproximadamente 7 días.
+- El _README_ debe contener todas las instrucciones para poder levantar la aplicación, en caso de ser necesario, y explicar cómo se usa.
+- Disponibilidad para realizar una pequeña demo del proyecto al finalizar el _challenge_.
+- Tiempo para la entrega: aproximadamente 7 días.


### PR DESCRIPTION
# Cambios (simples) realizados
- [Uso de itálica para palabras en inglés.](https://www.rae.es/espanol-al-dia/los-extranjerismos-y-latinismos-crudos-no-adaptados-deben-escribirse-en-cursiva)
- Algunos cambios de ortografía (puede que me haya equivocado 🤐).
- Algunos cambios estéticos (jaja es subjetivo, pero espero les sirva. Y si no, me lo comentan y lo devuelvo a su estado inicial antes del _merge_).
- Aclaración del cambio en la línea 37 (mayúscula tras los dos puntos): ver ejemplos de 1.1 y 1.2 de [este lugar del Internet](https://www.rae.es/dpd/dos%20puntos) 🌐.

**P.D.**: ya sé que no soy parte de la empresa, pero siento a esto como una mini contribución que puedo hacer al _software_ libre (de ustedes en este caso), así que le mandé mecha nomás. 🤷🏼‍♂️